### PR TITLE
Add -version flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,9 +42,17 @@ import (
 )
 
 func main() {
+	var version bool
+
 	flag.Usage = printPushupHelp
+	flag.BoolVar(&version, "version", false, "Print the version number and exit")
 
 	flag.Parse()
+
+	if version {
+		printVersion()
+		os.Exit(0)
+	}
 
 	if flag.NArg() == 0 {
 		printPushupHelp()
@@ -320,6 +328,9 @@ var commands = []command{
 func printPushupHelp() {
 	w := tabwriter.NewWriter(os.Stderr, 0, 0, 1, ' ', 0)
 	fmt.Fprintln(w, "Usage: pushup [command] [options]")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Flags:")
+	fmt.Fprintln(w, "\t-version\t\tPrint the version number and exit")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Commands:")
 	for _, cmd := range commands {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+const (
+	VERSION = "0.0.1"
+)
+
+// getRuntimeVersion searches the buildinfo built into the binary to find and
+// return the git revision, if present. Returns an empty string otherwise.
+func getRuntimeVersion() string {
+	if bi, ok := debug.ReadBuildInfo(); !ok {
+		panic("Unable to get build info")
+	} else {
+		for i := range bi.Settings {
+			if bi.Settings[i].Key == "vcs.revision" {
+				return bi.Settings[i].Value
+			}
+		}
+	}
+	return ""
+}
+
+func printVersion() {
+	runtimeVersion := getRuntimeVersion()
+
+	// If the binary was not compiled with a git version, don't print an empty
+	// parens
+	if runtimeVersion == "" {
+		fmt.Printf("Pushup %s\n", VERSION)
+	} else {
+		fmt.Printf("Pushup %s (%s)\n", VERSION, runtimeVersion[:8])
+	}
+}


### PR DESCRIPTION
I mostly wanted to add this because it helps me to make sure I'm using the right version of pushup - after this patch `pushup -version` will show you the git revision of the binary.

`pushup -version` output:

```
$ ./pushup -version
Pushup 0.0.1 (ec08f68c)
```

Updated `pushup -help` output:

```
$ ./pushup -help
Usage: pushup [command] [options]

Flags:
 -version  Print the version number and exit

Commands:
 new [path]  create new Pushup project directory
 build       compile Pushup project and build executable
 run         build and run Pushup project app
```
