### PR TITLE
FIX: Missing trailing slashes in CRUD demo

### DIFF
--- a/example/app/pages/crud/album/$id.up
+++ b/example/app/pages/crud/album/$id.up
@@ -14,7 +14,7 @@
 
 <h1>Album</h1>
 
-<p><a href="/crud">Back to album list</a></p>
+<p><a href="/crud/">Back to album list</a></p>
 
 <style>
 dl { display: flex; flex-flow: row wrap; }

--- a/example/app/pages/crud/album/delete/$id.up
+++ b/example/app/pages/crud/album/delete/$id.up
@@ -15,7 +15,7 @@
         if err := deleteAlbum(DB, id); err != nil {
             return err
         }
-        http.Redirect(w, req, "/crud", http.StatusSeeOther)
+        http.Redirect(w, req, "/crud/", http.StatusSeeOther)
         return nil
     }
 }

--- a/example/app/pages/crud/album/edit/$id.up
+++ b/example/app/pages/crud/album/edit/$id.up
@@ -57,7 +57,7 @@
                 http.Error(w, http.StatusText(500), 500)
                 return nil
             }
-            http.Redirect(w, req, "/crud", http.StatusSeeOther)
+            http.Redirect(w, req, "/crud/", http.StatusSeeOther)
         }
     }
 }

--- a/example/app/pages/crud/album/new.up
+++ b/example/app/pages/crud/album/new.up
@@ -48,14 +48,14 @@
                 http.Error(w, http.StatusText(500), 500)
                 return nil
             }
-            http.Redirect(w, req, "/crud", http.StatusSeeOther)
+            http.Redirect(w, req, "/crud/", http.StatusSeeOther)
         }
     }
 }
 
 <h1>Add new album</h1>
 
-<p><a href="/crud">Cancel</a></p>
+<p><a href="/crud/">Cancel</a></p>
 
 <style>
 form { border: 1px solid #ddd; background: #f3f4f0; padding: 2rem; }

--- a/example/go.mod
+++ b/example/go.mod
@@ -2,4 +2,4 @@ module github.com/adhocteam/pushup/example
 
 go 1.18
 
-require github.com/mattn/go-sqlite3 v1.14.14 // indirect
+require github.com/mattn/go-sqlite3 v1.14.14


### PR DESCRIPTION
## Issue

In the `example` app, redirects to `/crud` returns 404.

## Solution

Redirect to `/crud/`.

## Misc

Ran `go mod tidy` to move indirect `sqlite` dependency to a required dependency.