### PR TITLE
fix staticcheck errors and run gofmt

### DIFF
--- a/_runtime/cmd/main.go
+++ b/_runtime/cmd/main.go
@@ -111,7 +111,7 @@ func pushupHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := build.Respond(w, r); err != nil {
 		logger.Printf("responding with route: %v", err)
-		if errors.Is(err, build.NotFound) {
+		if errors.Is(err, build.ErrNotFound) {
 			http.NotFound(w, r)
 		} else {
 			http.Error(w, http.StatusText(500), 500)

--- a/_runtime/pushup_support.go
+++ b/_runtime/pushup_support.go
@@ -84,7 +84,7 @@ func regexPatFromRoute(route string) routePat {
 	return routePat{strings.Join(out, "/"), slugs}
 }
 
-var NotFound = errors.New("page not found")
+var ErrNotFound = errors.New("page not found")
 
 type ctxKey struct{}
 
@@ -92,7 +92,7 @@ func Respond(w http.ResponseWriter, r *http.Request) error {
 	routeMatch := getRouteFromPath(r.URL.Path)
 	switch routeMatch.response {
 	case routeNotFound:
-		return NotFound
+		return ErrNotFound
 	case redirectTrailingSlash:
 		http.Redirect(w, r, routeMatch.route.path, http.StatusMovedPermanently)
 		return nil

--- a/_runtime/pushup_support.go
+++ b/_runtime/pushup_support.go
@@ -94,7 +94,7 @@ func Respond(w http.ResponseWriter, r *http.Request) error {
 	case routeNotFound:
 		return NotFound
 	case redirectTrailingSlash:
-		http.Redirect(w, r, routeMatch.route.path, 301)
+		http.Redirect(w, r, routeMatch.route.path, http.StatusMovedPermanently)
 		return nil
 	case routeFound:
 		route := routeMatch.route
@@ -114,7 +114,6 @@ func Respond(w http.ResponseWriter, r *http.Request) error {
 	default:
 		panic("unhandled route match response")
 	}
-	return nil
 }
 
 func mostSpecificMatch(routes []*route, path string) *route {
@@ -293,10 +292,7 @@ func isPartialRoute(mainRoute string, requestPath string) bool {
 	match := getRouteFromPath(requestPath)
 	if match.response == routeFound {
 		route := match.route
-		if route.path == mainRoute {
-			return false
-		}
-		return true
+		return route.path != mainRoute
 	}
 	panic("internal error: unexpected path")
 }
@@ -308,15 +304,12 @@ func displayPartialHere(mainRoute string, partialPath string, requestPath string
 	} else {
 		path = mainRoute + partialPath
 	}
-	//log.Printf("PATH: %v\tREQUEST_PATH: %v", path, requestPath)
+	// log.Printf("PATH: %v\tREQUEST_PATH: %v", path, requestPath)
 	match := getRouteFromPath(path)
 	if match.response == routeFound {
-		if matchURLPathSegmentPrefix(match.route.regex, requestPath) {
-			return true
-		}
-		return false
+		return matchURLPathSegmentPrefix(match.route.regex, requestPath)
 	}
-	//log.Printf("MAIN ROUTE: %v\tPARTIAL PATH: %v\tREQUEST PATH: %v", mainRoute, partialPath, requestPath)
+	// log.Printf("MAIN ROUTE: %v\tPARTIAL PATH: %v\tREQUEST PATH: %v", mainRoute, partialPath, requestPath)
 	panic("internal error: unexpected path")
 }
 
@@ -375,7 +368,7 @@ func matchURLPathSegmentPrefix(re *regexp.Regexp, s string) bool {
 	if s != "" {
 		segments = strings.Split(s, "/")
 	}
-	//log.Printf("RESEGMENTS: %#v\tSEGMENTS: %#v", reSegments, segments)
+	// log.Printf("RESEGMENTS: %#v\tSEGMENTS: %#v", reSegments, segments)
 	for i := 0; i < min(len(reSegments), len(segments)); i++ {
 		reseg := reSegments[i]
 		seg := segments[i]
@@ -383,10 +376,7 @@ func matchURLPathSegmentPrefix(re *regexp.Regexp, s string) bool {
 			return false
 		}
 	}
-	if len(segments) > len(reSegments) {
-		return false
-	}
-	return true
+	return len(segments) <= len(reSegments)
 }
 
 func min(a int, b int) int {

--- a/_runtime/pushup_support.go
+++ b/_runtime/pushup_support.go
@@ -304,12 +304,10 @@ func displayPartialHere(mainRoute string, partialPath string, requestPath string
 	} else {
 		path = mainRoute + partialPath
 	}
-	// log.Printf("PATH: %v\tREQUEST_PATH: %v", path, requestPath)
 	match := getRouteFromPath(path)
 	if match.response == routeFound {
 		return matchURLPathSegmentPrefix(match.route.regex, requestPath)
 	}
-	// log.Printf("MAIN ROUTE: %v\tPARTIAL PATH: %v\tREQUEST PATH: %v", mainRoute, partialPath, requestPath)
 	panic("internal error: unexpected path")
 }
 
@@ -368,7 +366,6 @@ func matchURLPathSegmentPrefix(re *regexp.Regexp, s string) bool {
 	if s != "" {
 		segments = strings.Split(s, "/")
 	}
-	// log.Printf("RESEGMENTS: %#v\tSEGMENTS: %#v", reSegments, segments)
 	for i := 0; i < min(len(reSegments), len(segments)); i++ {
 		reseg := reSegments[i]
 		seg := segments[i]

--- a/main.go
+++ b/main.go
@@ -657,8 +657,6 @@ func findProjectFiles(appDir string) (*projectFiles, error) {
 		}
 	}
 
-	// pf.debug()
-
 	return pf, nil
 }
 
@@ -841,7 +839,7 @@ func compile(params compileParams) error {
 		codeGen := newLayoutCodeGen(layout, params.pfile, src)
 		code, err = genCodeLayout(codeGen)
 		if err != nil {
-			return fmt.Errorf("generating code layout: %w", err)
+			return fmt.Errorf("generating code for a layout: %w", err)
 		}
 	case upFilePage:
 		page, err := newPageFromTree(tree)
@@ -1111,8 +1109,6 @@ outputSection := func(name string) template.HTML {
 	if err != nil {
 		return nil, fmt.Errorf("reading all buffers: %w", err)
 	}
-
-	// fmt.Fprintf(os.Stderr, "\x1b[36m%s\x1b[0m", string(raw))
 
 	formatted, err := format.Source(raw)
 	if err != nil {
@@ -1734,15 +1730,11 @@ func genCodePage(g *pageCodeGen) ([]byte, error) {
 		return nil, fmt.Errorf("reading all buffers: %w", err)
 	}
 
-	// fmt.Fprintf(os.Stderr, "\x1b[36m%s\x1b[0m", string(raw))
-
 	formatted, err := format.Source(raw)
 	if err != nil {
 		log.Printf("ERROR: %v", err)
 		return nil, fmt.Errorf("gofmt the generated code: %w", err)
 	}
-
-	// fmt.Fprintf(os.Stderr, "\x1b[36m%s\x1b[0m", string(formatted))
 
 	return formatted, nil
 }
@@ -1754,7 +1746,6 @@ func watchForReload(ctx context.Context, cancel context.CancelFunc, root string,
 	}
 
 	go debounceEvents(ctx, 125*time.Millisecond, watcher, func(event fsnotify.Event) {
-		// log.Printf("name: %s\top: %s", event.Name, event.Op)
 		if !reloadableFilename(event.Name) {
 			return
 		}
@@ -2019,7 +2010,6 @@ func debounceEvents(ctx context.Context, interval time.Duration, watcher *fsnoti
 			}
 			log.Printf("file watch error: %v", err)
 		case ev, ok := <-watcher.Events:
-			// log.Printf("GOT EVENT: %s %d", ev.String(), ev.Op)
 			if !ok {
 				return
 			}
@@ -2621,7 +2611,6 @@ func coalesceLiterals(nodes []node) []node {
 		}
 		nodes = nodes[:n+1]
 	}
-	// log.Printf("SAVED %d NODES", before-len(nodes))
 	return nodes
 }
 
@@ -3252,7 +3241,6 @@ func (p *codeParser) lookahead() goToken {
 	} else {
 		t.lit = t.tok.String()
 	}
-	// log.Printf("pos %v\ttok %v\tlit %v", t.pos, t.tok, t.lit)
 	return t
 }
 
@@ -4427,11 +4415,9 @@ func (l *openTagLexer) reconsumeIn(state openTagLexState) {
 }
 
 func (l *openTagLexer) exitingState(state openTagLexState) {
-	// log.Printf("<- %s", state)
 }
 
 func (l *openTagLexer) enteringState(state openTagLexState) {
-	// log.Printf("-> %s", state)
 }
 
 func (l *openTagLexer) switchState(state openTagLexState) {


### PR DESCRIPTION
- Fix shadowed variables reported by staticcheck
- Use `os.MkTempDirs` instead of the deprecated `ioutil.TempDir`
- Un-name some unused variables
- `301` -> `http.StatusMovedPermanently`
- remove unreachable code
- simplify some boolean returns
- change some switches to switch on the character when possible
  - If you want me to remove these switch changes for stylistic reasons, I'm totally open to that. I think they read better this way, but they don't exactly rhyme now, and future changes might require undoing switching on the character
- gofmt

Before:

```
$ staticcheck . ./_runtime
_runtime/pushup_support.go:87:5: error var NotFound should have name of the form ErrFoo (ST1012)
_runtime/pushup_support.go:97:46: should use constant http.StatusMovedPermanently instead of numeric literal 301 (ST1013)
_runtime/pushup_support.go:180:6: func getParam is unused (U1000)
_runtime/pushup_support.go:189:5: var layouts is unused (U1000)
_runtime/pushup_support.go:191:6: func getLayout is unused (U1000)
_runtime/pushup_support.go:202:6: type nilLayout is unused (U1000)
_runtime/pushup_support.go:204:21: func (*nilLayout).Respond is unused (U1000)
_runtime/pushup_support.go:230:6: func printEscaped is unused (U1000)
_runtime/pushup_support.go:296:3: should use 'return route.path != mainRoute' instead of 'if route.path == mainRoute { return false }; return true' (S1008)
_runtime/pushup_support.go:314:3: should use 'return matchURLPathSegmentPrefix(match.route.regex, requestPath)' instead of 'if matchURLPathSegmentPrefix(match.route.regex, requestPath) { return true }; return false' (S1008)
_runtime/pushup_support.go:386:2: should use 'return len(segments) <= len(reSegments)' instead of 'if len(segments) > len(reSegments) { return false }; return true' (S1008)
main.go:17:2: \"io/ioutil\" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
main.go:566:24: func (*projectFiles).debug is unused (U1000)
main.go:843:3: this value of err is never used (SA4006)
main.go:850:3: this value of err is never used (SA4006)
main.go:871:2: should merge variable declaration with assignment on next line (S1021)
main.go:3683:22: func (*codeParser).offset is unused (U1000)
$ go vet . ./_runtime
# github.com/adhocteam/pushup/_runtime
_runtime/pushup_support.go:117:2: unreachable code
```

After:

```
$ staticcheck . ./_runtime
_runtime/pushup_support.go:179:6: func getParam is unused (U1000)
_runtime/pushup_support.go:188:5: var layouts is unused (U1000)
_runtime/pushup_support.go:190:6: func getLayout is unused (U1000)
_runtime/pushup_support.go:201:6: type nilLayout is unused (U1000)
_runtime/pushup_support.go:203:21: func (*nilLayout).Respond is unused (U1000)
_runtime/pushup_support.go:229:6: func printEscaped is unused (U1000)
main.go:565:24: func (*projectFiles).debug is unused (U1000)
main.go:3675:22: func (*codeParser).offset is unused (U1000)
$ go vet . ./_runtime
```

- obviously runtime functions being unused is not an issue
- I didn't want to rename `NotFound` without putting it in front of you first
- I thought maybe you wanted to keep the unused functions in `main.go` around for future use
- In the future, we may want to add checks like these to CI