### PR TITLE
remove cmd.Wait in test process killing goroutine

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -221,7 +221,6 @@ func TestPushup(t *testing.T) {
 							case <-done:
 								if cmd != nil {
 									syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
-									cmd.Wait()
 								}
 								return nil
 							case <-ctx.Done():


### PR DESCRIPTION
See https://github.com/adhocteam/pushup/issues/38 for evidence that it's causing #38. I can't say that I have a good theory for _why_, but empirically the tests don't hang and they seem to do what they're supposed to without it.
