### PR TITLE
Mangle buffer name

### DIFF
--- a/main.go
+++ b/main.go
@@ -1666,16 +1666,16 @@ func genCodePage(g *pageCodeGen) ([]byte, error) {
 		g.bodyPrintf("  }()\n")
 		g.used("bytes", "html/template")
 		save := g.ioWriterVar
-		g.ioWriterVar = "b"
+		g.ioWriterVar = "__pushup_b"
 		g.bodyPrintf("  %s := new(bytes.Buffer)\n", g.ioWriterVar)
 		g.generate()
-		g.bodyPrintf("  sections[\"contents\"] <- template.HTML(b.String())\n")
+		g.bodyPrintf("  sections[\"contents\"] <- template.HTML(%s.String())\n", g.ioWriterVar)
 		g.bodyPrintf("}()\n\n")
 		g.ioWriterVar = save
 
 		for name, block := range g.page.sections {
 			save := g.ioWriterVar
-			g.ioWriterVar = "b"
+			g.ioWriterVar = "__pushup_b"
 			g.bodyPrintf("wg.Add(1)\n")
 			g.bodyPrintf("go func() {\n")
 			g.bodyPrintf("  defer wg.Done()\n")
@@ -1689,7 +1689,7 @@ func genCodePage(g *pageCodeGen) ([]byte, error) {
 			g.bodyPrintf("  }()\n")
 			g.bodyPrintf("  %s := new(bytes.Buffer)\n", g.ioWriterVar)
 			g.genNode(block)
-			g.bodyPrintf("  sections[%s] <- template.HTML(b.String())\n", strconv.Quote(name))
+			g.bodyPrintf("  sections[%s] <- template.HTML(%s.String())\n", strconv.Quote(name), g.ioWriterVar)
 			g.bodyPrintf("}()\n")
 			g.ioWriterVar = save
 		}


### PR DESCRIPTION
rather than preventing users from using the name 'b', let's mangle our own names to something they're unlikely to want to use.

Generated code, before:

```go
			b := new(bytes.Buffer)
//line dump.up:2
			io.WriteString(b, "\n\n")
//line dump.up:3
			io.WriteString(b, "<h2>")
//line dump.up:3
			io.WriteString(b, "Dump request headers")
//line dump.up:3
			io.WriteString(b, "</h2>")
<snip>
			sections["contents"] <- template.HTML(b.String())
```

Generated code, after:

```go
			__pushup_b := new(bytes.Buffer)
//line dump.up:2
			io.WriteString(__pushup_b, "\n\n")
//line dump.up:3
			io.WriteString(__pushup_b, "<h2>")
//line dump.up:3
			io.WriteString(__pushup_b, "Dump request headers")
//line dump.up:3
			io.WriteString(__pushup_b, "</h2>")
<snip>
			sections["contents"] <- template.HTML(__pushup_b.String())
```

- Also fix a few spots where `b` was hardcoded

Fixes #88
