### PR TITLE
Fix the doc link on the Hello world page

### DIFF
--- a/scaffold/pages/index.up
+++ b/scaffold/pages/index.up
@@ -51,6 +51,6 @@
             <li>Great, you set the <tt>-dev</tt> flag for live reloading!</li>
         }
         <li>Add new Pushup pages to <tt>app/pages</tt> and see them appear as routes</li>
-        <li><a href="https://adhocteam.github.io/pushup/docs/">Read the docs</a></li>
+        <li><a href="https://pushup.adhoc.dev/docs/">Read the docs</a></li>
     </ul>
 </section>


### PR DESCRIPTION
Hi Paul,

Thanks for this awesome project.

It seems that the link `adhocteam.github.io/pushup/docs/` returns a 404 error. I have updated the link to `pushup.adhoc.dev/docs/` on the index.up