### PR TITLE
parser: Handle self-closing elements and void elements

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -177,6 +177,7 @@ type nodeElement struct {
 	startTagNodes []node
 	children      []node
 	pos           span
+	selfClosing   bool
 }
 
 func (e nodeElement) Pos() span { return e.pos }

--- a/parser_test.go
+++ b/parser_test.go
@@ -405,6 +405,27 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			`^if true { <br/> }`,
+			&syntaxTree{
+				nodes: []node{
+					&nodeIf{
+						cond: &nodeGoStrExpr{expr: "true", pos: span{start: 4, end: 8}},
+						then: &nodeBlock{
+							nodes: []node{
+								&nodeLiteral{str: " ", pos: span{10, 11}},
+								&nodeElement{
+									tag:           tag{name: "br"},
+									startTagNodes: []node{&nodeLiteral{str: "<br/>", pos: span{start: 11, end: 16}}},
+									pos:           span{11, 16},
+									selfClosing:   true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	opts := cmp.AllowUnexported(unexported...)
 	for _, test := range tests {
@@ -450,7 +471,7 @@ func TestParseSyntaxErrors(t *testing.T) {
 		{
 			`^if true {
 	<illegal />
-}`, 2, 13,
+}`, 3, 2,
 		},
 		// FIXME(paulsmith): add more syntax errors
 	}


### PR DESCRIPTION
- Add `selfClosing` field to `nodeElement` struct to track self-closing tags
- Update `match` function to accept multiple token types
- Check for self-closing tags in `parseElement` and set `selfClosing` field
- Return early for void elements in `parseElement`
- Refactor `parseChildren` to handle both start and self-closing tags
- Add `isVoidElement` function to check if a tag is a void element
- Update tests to cover self-closing and void elements

🌟 These changes improve the HTML parser to properly handle self-closing elements and void elements according to the HTML spec.

Fixes #126