### PR TITLE
Use localhost as default host to listen on

### DIFF
--- a/_runtime/cmd/main.go
+++ b/_runtime/cmd/main.go
@@ -65,7 +65,7 @@ func main() {
 		if *unixSocket != "" {
 			ln, err = net.Listen("unix", *unixSocket)
 		} else {
-			host := "0.0.0.0"
+			host := "localhost"
 			addr := host + ":" + *port
 			ln, err = net.Listen("tcp4", addr) // TODO(paulsmith): may want to support IPv6
 		}


### PR DESCRIPTION
This will prevent macOS from issuing pop-up modals asking for approval for network access